### PR TITLE
spark sql解析为phoenix sql 问题

### DIFF
--- a/phoenix-assembly/pom.xml
+++ b/phoenix-assembly/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-assembly</artifactId>
   <name>Phoenix Assembly</name>

--- a/phoenix-client/pom.xml
+++ b/phoenix-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-client</artifactId>
   <name>Phoenix Client</name>

--- a/phoenix-core/pom.xml
+++ b/phoenix-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-core</artifactId>
   <name>Phoenix Core</name>

--- a/phoenix-flume/pom.xml
+++ b/phoenix-flume/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-flume</artifactId>
   <name>Phoenix - Flume</name>

--- a/phoenix-hive/pom.xml
+++ b/phoenix-hive/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-hive</artifactId>
   <name>Phoenix - Hive</name>

--- a/phoenix-kafka/pom.xml
+++ b/phoenix-kafka/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.apache.phoenix</groupId>
 		<artifactId>phoenix</artifactId>
-		<version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+		<version>4.14.1-HBase-1.2-GIO-2.1.7</version>
 	</parent>
 	<artifactId>phoenix-kafka</artifactId>
 	<name>Phoenix - Kafka</name>

--- a/phoenix-load-balancer/pom.xml
+++ b/phoenix-load-balancer/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-load-balancer</artifactId>
   <name>Phoenix Load Balancer</name>

--- a/phoenix-pherf/pom.xml
+++ b/phoenix-pherf/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.apache.phoenix</groupId>
 		<artifactId>phoenix</artifactId>
-		<version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+		<version>4.14.1-HBase-1.2-GIO-2.1.7</version>
 	</parent>
 
 	<artifactId>phoenix-pherf</artifactId>

--- a/phoenix-pig/pom.xml
+++ b/phoenix-pig/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-pig</artifactId>
   <name>Phoenix - Pig</name>

--- a/phoenix-queryserver-client/pom.xml
+++ b/phoenix-queryserver-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-queryserver-client</artifactId>
   <name>Phoenix Query Server Client</name>

--- a/phoenix-queryserver/pom.xml
+++ b/phoenix-queryserver/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-queryserver</artifactId>
   <name>Phoenix Query Server</name>

--- a/phoenix-server/pom.xml
+++ b/phoenix-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-server</artifactId>
   <name>Phoenix Server</name>

--- a/phoenix-spark/pom.xml
+++ b/phoenix-spark/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-spark</artifactId>
   <name>Phoenix - Spark</name>

--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -26,7 +26,7 @@ import org.apache.phoenix.util.StringUtil.escapeStringConstant
 import org.apache.phoenix.util.SchemaUtil
 
 case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Boolean = false)(@transient val sqlContext: SQLContext)
-    extends BaseRelation with PrunedFilteredScan {
+  extends BaseRelation with PrunedFilteredScan {
 
   /*
     This is the buildScan() implementing Spark's PrunedFilteredScan.
@@ -67,14 +67,14 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
       return ""
     }
 
-//    val filter = new StringBuilder("")
-//    var i = 0
+    //    val filter = new StringBuilder("")
+    //    var i = 0
 
     filters.map(f => {
       // Assume conjunction for multiple filters, unless otherwise specified
-//      if (i > 0) {
-//        (" AND")
-//      }
+      //      if (i > 0) {
+      //        (" AND")
+      //      }
 
       f match {
         // Spark 1.3.1+ supported filters
@@ -94,10 +94,10 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
         case StringContains(attr, value) => (s" ${escapeKey(attr)} LIKE ${compileValue("%" + value + "%")}")
       }
 
-//      i = i + 1
+      //      i = i + 1
     }).mkString("(",") AND (",")")
 
-//     filter.toString()
+    //     filter.toString()
   }
 
   // Helper function to escape column key to work with SQL queries
@@ -119,14 +119,5 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
 
   private def isClass(obj: Any, className: String) = {
     className.equals(obj.getClass().getName())
-  }
-
-  private def escapeStringValue(content: String) = {
-    if (!content.contains("\\\'")) {
-      val escapeContent = content.replace("'", "''")
-      s"'$escapeContent'"
-    } else {
-      s"'${content.replace("\\\'", "\\\\\\\'")}'"
-    }
   }
 }

--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -26,7 +26,7 @@ import org.apache.phoenix.util.StringUtil.escapeStringConstant
 import org.apache.phoenix.util.SchemaUtil
 
 case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Boolean = false)(@transient val sqlContext: SQLContext)
-    extends BaseRelation with PrunedFilteredScan {
+  extends BaseRelation with PrunedFilteredScan {
 
   /*
     This is the buildScan() implementing Spark's PrunedFilteredScan.
@@ -67,14 +67,14 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
       return ""
     }
 
-//    val filter = new StringBuilder("")
-//    var i = 0
+    //    val filter = new StringBuilder("")
+    //    var i = 0
 
     filters.map(f => {
       // Assume conjunction for multiple filters, unless otherwise specified
-//      if (i > 0) {
-//        (" AND")
-//      }
+      //      if (i > 0) {
+      //        (" AND")
+      //      }
 
       f match {
         // Spark 1.3.1+ supported filters
@@ -94,10 +94,10 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
         case StringContains(attr, value) => (s" ${escapeKey(attr)} LIKE ${compileValue("%" + value + "%")}")
       }
 
-//      i = i + 1
+      //      i = i + 1
     }).mkString("(",") AND (",")")
 
-//     filter.toString()
+    //     filter.toString()
   }
 
   // Helper function to escape column key to work with SQL queries
@@ -105,13 +105,13 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
 
   // Helper function to escape string values in SQL queries
   private def compileValue(value: Any): Any = value match {
-    case stringValue: String => s"'${escapeStringConstant(stringValue)}'"
+    case stringValue: String => escapeStringValue(stringValue)
 
     // Borrowed from 'elasticsearch-hadoop', support these internal UTF types across Spark versions
     // Spark 1.4
-    case utf if (isClass(utf, "org.apache.spark.sql.types.UTF8String")) => s"'${escapeStringConstant(utf.toString)}'"
+    case utf if (isClass(utf, "org.apache.spark.sql.types.UTF8String")) => escapeStringValue(utf.toString)
     // Spark 1.5
-    case utf if (isClass(utf, "org.apache.spark.unsafe.types.UTF8String")) => s"'${escapeStringConstant(utf.toString)}'"
+    case utf if (isClass(utf, "org.apache.spark.unsafe.types.UTF8String")) => escapeStringValue(utf.toString)
 
     // Pass through anything else
     case _ => value
@@ -120,4 +120,15 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
   private def isClass(obj: Any, className: String) = {
     className.equals(obj.getClass().getName())
   }
+
+
+  private def escapeStringValue(content: String) = {
+    if (!content.contains("\\\'")) {
+      val escapeContent = content.replace("'", "''")
+      s"'$escapeContent'"
+    } else {
+      s"'${content.replace("\\\'", "\\\\\\\'")}'"
+    }
+  }
+
 }

--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -26,7 +26,7 @@ import org.apache.phoenix.util.StringUtil.escapeStringConstant
 import org.apache.phoenix.util.SchemaUtil
 
 case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Boolean = false)(@transient val sqlContext: SQLContext)
-  extends BaseRelation with PrunedFilteredScan {
+    extends BaseRelation with PrunedFilteredScan {
 
   /*
     This is the buildScan() implementing Spark's PrunedFilteredScan.
@@ -67,14 +67,14 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
       return ""
     }
 
-    //    val filter = new StringBuilder("")
-    //    var i = 0
+//    val filter = new StringBuilder("")
+//    var i = 0
 
     filters.map(f => {
       // Assume conjunction for multiple filters, unless otherwise specified
-      //      if (i > 0) {
-      //        (" AND")
-      //      }
+//      if (i > 0) {
+//        (" AND")
+//      }
 
       f match {
         // Spark 1.3.1+ supported filters
@@ -94,10 +94,10 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
         case StringContains(attr, value) => (s" ${escapeKey(attr)} LIKE ${compileValue("%" + value + "%")}")
       }
 
-      //      i = i + 1
+//      i = i + 1
     }).mkString("(",") AND (",")")
 
-    //     filter.toString()
+//     filter.toString()
   }
 
   // Helper function to escape column key to work with SQL queries
@@ -105,13 +105,13 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
 
   // Helper function to escape string values in SQL queries
   private def compileValue(value: Any): Any = value match {
-    case stringValue: String => escapeStringValue(stringValue)
+    case stringValue: String => s"'${escapeStringConstant(stringValue)}'"
 
     // Borrowed from 'elasticsearch-hadoop', support these internal UTF types across Spark versions
     // Spark 1.4
-    case utf if (isClass(utf, "org.apache.spark.sql.types.UTF8String")) => escapeStringValue(utf.toString)
+    case utf if (isClass(utf, "org.apache.spark.sql.types.UTF8String")) => s"'${escapeStringConstant(utf.toString)}'"
     // Spark 1.5
-    case utf if (isClass(utf, "org.apache.spark.unsafe.types.UTF8String")) => escapeStringValue(utf.toString)
+    case utf if (isClass(utf, "org.apache.spark.unsafe.types.UTF8String")) => s"'${escapeStringConstant(utf.toString)}'"
 
     // Pass through anything else
     case _ => value
@@ -121,7 +121,6 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
     className.equals(obj.getClass().getName())
   }
 
-
   private def escapeStringValue(content: String) = {
     if (!content.contains("\\\'")) {
       val escapeContent = content.replace("'", "''")
@@ -130,5 +129,4 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
       s"'${content.replace("\\\'", "\\\\\\\'")}'"
     }
   }
-
 }

--- a/phoenix-tracing-webapp/pom.xml
+++ b/phoenix-tracing-webapp/pom.xml
@@ -27,7 +27,7 @@
     <parent>
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix</artifactId>
-      <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+      <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
     </parent>
 
     <artifactId>phoenix-tracing-webapp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.phoenix</groupId>
   <artifactId>phoenix</artifactId>
-  <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+  <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   <packaging>pom</packaging>
   <name>Apache Phoenix</name>
   <description>A SQL layer over HBase</description>


### PR DESCRIPTION
spark通过phoenix查询hbase的过程中，会先把spark sql转为为phoenix sql。
转为规则为'变为''。当value存在\\\'时，会出现字符串异常。