### PR TITLE
spark sql解析phoenix sql 问题

### DIFF
--- a/phoenix-assembly/pom.xml
+++ b/phoenix-assembly/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-assembly</artifactId>
   <name>Phoenix Assembly</name>

--- a/phoenix-client/pom.xml
+++ b/phoenix-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-client</artifactId>
   <name>Phoenix Client</name>

--- a/phoenix-core/pom.xml
+++ b/phoenix-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-core</artifactId>
   <name>Phoenix Core</name>

--- a/phoenix-flume/pom.xml
+++ b/phoenix-flume/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-flume</artifactId>
   <name>Phoenix - Flume</name>

--- a/phoenix-hive/pom.xml
+++ b/phoenix-hive/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-hive</artifactId>
   <name>Phoenix - Hive</name>

--- a/phoenix-kafka/pom.xml
+++ b/phoenix-kafka/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.apache.phoenix</groupId>
 		<artifactId>phoenix</artifactId>
-		<version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+		<version>4.14.1-HBase-1.2-GIO-2.1.7</version>
 	</parent>
 	<artifactId>phoenix-kafka</artifactId>
 	<name>Phoenix - Kafka</name>

--- a/phoenix-load-balancer/pom.xml
+++ b/phoenix-load-balancer/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-load-balancer</artifactId>
   <name>Phoenix Load Balancer</name>

--- a/phoenix-pherf/pom.xml
+++ b/phoenix-pherf/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.apache.phoenix</groupId>
 		<artifactId>phoenix</artifactId>
-		<version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+		<version>4.14.1-HBase-1.2-GIO-2.1.7</version>
 	</parent>
 
 	<artifactId>phoenix-pherf</artifactId>

--- a/phoenix-pig/pom.xml
+++ b/phoenix-pig/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-pig</artifactId>
   <name>Phoenix - Pig</name>

--- a/phoenix-queryserver-client/pom.xml
+++ b/phoenix-queryserver-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-queryserver-client</artifactId>
   <name>Phoenix Query Server Client</name>

--- a/phoenix-queryserver/pom.xml
+++ b/phoenix-queryserver/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-queryserver</artifactId>
   <name>Phoenix Query Server</name>

--- a/phoenix-server/pom.xml
+++ b/phoenix-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-server</artifactId>
   <name>Phoenix Server</name>

--- a/phoenix-spark/pom.xml
+++ b/phoenix-spark/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+    <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   </parent>
   <artifactId>phoenix-spark</artifactId>
   <name>Phoenix - Spark</name>

--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -17,12 +17,12 @@
  */
 package org.apache.phoenix.spark
 
+import org.apache.commons.lang.StringEscapeUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.sql.sources._
-import org.apache.phoenix.util.StringUtil.escapeStringConstant
 import org.apache.phoenix.util.SchemaUtil
 
 case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Boolean = false)(@transient val sqlContext: SQLContext)
@@ -122,11 +122,14 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
   }
 
   private def escapeStringValue(content: String) = {
-    if (!content.contains("\\\'")) {
-      val escapeContent = content.replace("'", "''")
-      s"'$escapeContent'"
+    if (content == null) {
+      s"'$content'"
     } else {
-      s"'${content.replace("\\\'", "\\\\\\\'")}'"
+      var escapeString: String = content
+      if (!content.contains("\\\\\\'")) {
+        escapeString = escapeString.replace("'", "''")
+      }
+      s"'$escapeString'"
     }
   }
 }

--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.phoenix.spark
 
-import org.apache.commons.lang.StringEscapeUtils
+import org.apache.commons.lang.{StringEscapeUtils, StringUtils}
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.StructType
@@ -126,10 +126,14 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
       s"'$content'"
     } else {
       var escapeString: String = content
-      if (!content.contains("\\\\\\'")) {
-        escapeString = escapeString.replace("'", "''")
+      if (!content.contains("\\\'")) {
+        escapeString = escapeString.replaceAll("'", "''")
+      } else {
+        escapeString = escapeString.replace("\\", "\\\\")
+        escapeString = escapeString.replace("\'", "\\'")
       }
       s"'$escapeString'"
+
     }
   }
 }

--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -122,18 +122,9 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
   }
 
   private def escapeStringValue(content: String) = {
-    if (content == null) {
-      s"'$content'"
-    } else {
-      var escapeString: String = content
-      if (!content.contains("\\\'")) {
-        escapeString = escapeString.replaceAll("'", "''")
-      } else {
-        escapeString = escapeString.replace("\\", "\\\\")
-        escapeString = escapeString.replace("\'", "\\'")
-      }
-      s"'$escapeString'"
-
+    content match {
+      case str if str != null => s"'${str.replace("\\", "\\\\").replace("'", "''")}'"
+      case _ => "'null'"
     }
   }
 }

--- a/phoenix-tracing-webapp/pom.xml
+++ b/phoenix-tracing-webapp/pom.xml
@@ -27,7 +27,7 @@
     <parent>
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix</artifactId>
-      <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+      <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
     </parent>
 
     <artifactId>phoenix-tracing-webapp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.phoenix</groupId>
   <artifactId>phoenix</artifactId>
-  <version>4.14.1-HBase-1.2-GIO-2.1.6</version>
+  <version>4.14.1-HBase-1.2-GIO-2.1.7</version>
   <packaging>pom</packaging>
   <name>Apache Phoenix</name>
   <description>A SQL layer over HBase</description>


### PR DESCRIPTION
spark通过phoenix查询hbase的过程中，会先把spark sql转为为phoenix sql。
转为规则为'变为''。当value存在\'时，会出现字符串异常。